### PR TITLE
add git-pr-chain new commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,13 @@
 `git-pr-chain` is an opinionated tool that manages dependent GitHub pull
 requests.
 
+Use `git-pr-chain` you will be able to:
+
+- ✅ Create multiple Github PRs with 1 local git branch (each with one or more commits)
+- ✅ Show the list of depedent PRs on the PR summary automatically
+- ✅ Rebase all PRs on top of the latest changes with 1 command
+- ✅ Update all PRs with one 1 command
+
 `git-pr-chain` works if you use a rebase/rewrite-history workflow locally, i.e.
 when you want to get new changes from upstream, you rebase onto the new master
 rather than merging master into your branch.  The tool has no opinion on how PRs
@@ -31,8 +38,10 @@ $ git commit -m "Add foo\ngit-pr-chain: add-foo"
 $ echo "blah blah" > foo
 $ git commit -a -m "Update foo"
 
+# We can also run `git-pr-chain new` to add PR-chain annotation automatically
 $ touch bar && git add bar
-$ git commit -m "Add bar\ngit-pr-chain: add-bar"
+$ git commit -m "Add bar"
+$ git-pr-chain new
 
 # We need to know what "upstream" is.
 $ git branch --set-upstream-to origin/master
@@ -55,18 +64,58 @@ $ git-pr-chain merge --merge-method=rebase
 # Merges "add-foo" (equivalent of clicking "merge" button on github)
 ```
 
-## Usage notes
+## Setting up
+
+### Grant Github access via `gh` or `hub`
+   `git-pr-chain` reads your github oauth token from
+   [`gh`](https://github.com/cli/cli) or [`hub`](https://github.com/github/hub),
+   because oauth is hard.  So you'll need to sign in to github with one of those
+   tools.
+
+### Setting up `git-pr-chain` as an executable
+
+Clone the repo and set it up as an executable
+```
+$ git clone git@github.com:jlebar/git-pr-chain.git
+$ ln -s /path/to/git-pr-chain/git-pr-chain.py /usr/local/bin/git-pr-chain
+```
+
+## Usage
+
+Run `git-pr-chain` to see available commands. Currently, the following commands are supported
+
+```
+    log                 List commits in chain
+    new                 Mark HEAD as starting a new PR in the chain
+    end-chain           Add a commit to mark the end of the chain
+    push                Create and update PRs in github
+    merge               Merge one (default) or more PRs (not yet implemented)
+```
+
+### Usage notes
 
  * If the `git-pr-chain:` annotation is missing, the commit will live on the
    same branch as the previous commit.  (The second commit in the example above
    takes advantage of this.)
 
+ * If any commit message contains the string `git-pr-chain: STOP`, it and all
+   further commits will not be pushed.
+
  * `git-pr-chain` adds info about the whole chain to each PR's description, but
    it won't (or, shouldn't!) overwrite changes you make to the PR outside of its
    `<git-pr-chain>` section.
 
- * If any commit message contains the string `git-pr-chain: STOP`, it and all
-   further commits will not be pushed.
+ * You can add following config to add a prefix to the branches created by git-pr-chain
+   `~/.gitconfig`:
+
+   ```
+   [pr-chain]
+       branch-prefix = "something/"
+   ```
+
+   This way if you have a commit with `git-pr-chain: foo`, it will correspond to
+   a remote branch named `something/foo`. Consider setting it to your
+   username.
 
  * You can write `GPC:` instead of `git-pr-chain:` in commit messages, if you
    like.
@@ -81,28 +130,10 @@ $ git-pr-chain merge --merge-method=rebase
    in that repo).  This is a limitation of github, as far as I can tell.  Let me
    know if you know how to work around it.
 
-   To make this slightly less painful, you can set the following in your
-   `~/.gitconfig`:
-
-   ```
-   [pr-chain]
-       branch-prefix = "something/"
-   ```
-
-   This way if you have a commit with `git-pr-chain: foo`, it will correspond to
-   a remote branch named `something/foo`.  This has no semantic meaning, but can
-   let others know that this is your private branch. Consider setting it to your
-   username.
-
  * If you merge many PRs in quick succession, Travis/CircleCI won't be able to
    keep up with the rapidly-changing branch bases and may send you many "build
    failed" emails.  CircleCI's seems to be less noisy in this failure mode than
    Travis; with Travis I once memorably got `O(n^2)` emails for a 20-PR chain.
-
- * `git-pr-chain` reads your github oauth token from
-   [`gh`](https://github.com/cli/cli) or [`hub`](https://github.com/github/hub),
-   because oauth is hard.  So you'll need to sign in to github with one of those
-   tools.
 
 ## FAQ
 

--- a/git-pr-chain.py
+++ b/git-pr-chain.py
@@ -110,7 +110,7 @@ def gh_repo_client():
     # Translate our remote's URL into a github user/repo string.  (Is there
     # seriously not a beter way to do this?)
     remote_url = git("remote", "get-url", remote)
-    match = re.search(r"(?:[/:])([^/:]+/[^/:]+)(\.git)?$", remote_url)
+    match = re.search(r"(?:[/:])([^/:]+/[^/:]+?)(\.git)?$", remote_url)
     if not match:
         fatal(
             f"Couldn't extract github user/repo from {remote} "

--- a/git-pr-chain.py
+++ b/git-pr-chain.py
@@ -746,7 +746,7 @@ def cmd_new_pr(args):
     if head_commit.not_to_be_pushed:
         fatal(
             "There is a git-pr-chain: STOP commit upstream of this commit."
-            "  Please move it down before creating a git-pr-chain for it."
+            "  Please remove it before running `git-pr-chain new`."
         )
 
     maybe_pr_chain = head_commit.parse_pr_chain


### PR DESCRIPTION
In this PR I introduce a new command `git-pr-chain new` to automagically create a `git-pr-chain:` token in a commit. It serves 2 purposes:
- Workflow wise, I create commits before thinking about making branches or marking them as the start of a new PR. This command allows me to easily go back and add `git-pr-chain` token to a commit.
- The chain name is irrelevant and can be generated from the commit message instead. One less thing I have to think about

It doesn't affect the existing work flow. People who want to add `git-pr-chain` to their commits manually can still do that.<git-pr-chain>

#### Commits in this PR
1. add git-pr-chain new command
1. add function to generate new branch name & update commit msg
1. update msg
1. make the new command dumb

#### [PR chain](https://github.com/jlebar/git-pr-chain)
1. 👉 #1 add git-pr-chain new command 👈 **YOU ARE HERE**
1. #2 fix remote url parser
1. #3 add a new command to mark the end of a chain
1. #8 use user login name as the default prefix


</git-pr-chain>






